### PR TITLE
Bisect improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ $ yarn test
   ...
 ```
 
+Run or debug locally  
+```bash
+yarn build
+
+GITHUB_WORKSPACE=/absolute/path/to/TypeScript \
+GITHUB_TOKEN=$token \          # will comment without DRY!
+DRY=1 \                        # do not post results comment
+ISSUE=50635 \                  # optional
+BISECT="good 4.7.3 bad main" \ # optional
+node lib/_main.js
+```
+
 ## To publish
 
 Actions are run from GitHub repos so we will check-in the packed dist folder. 

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,13 @@ inputs:
     description: 'What tag should be applied to the markdown code block?'
     default: 'repro'
 
+  issue:
+    required: false
+    description: 'Limits analysis to a single issue'
+
   bisect:
     required: false
-    description: 'Request a git bisect against an issue that already has a repro. Value is the issue number.'
+    description: 'Runs a git bisect on an existing repro. Requires `issue` to be set. Value can be revision labels (e.g. `good v4.7.3 bad main`) or `true` to infer bisect range.'
 
 runs:
   using: 'node16'

--- a/src/__tests__/getRequestsFromIssue.test.ts
+++ b/src/__tests__/getRequestsFromIssue.test.ts
@@ -10,8 +10,9 @@ const testCtx: Context = {
   token: '123456',
   tag: 'repro',
   workspace: '',
-  bisectIssue: undefined,
-  runIssue: undefined,
+  bisect: undefined,
+  issue: undefined,
+  dryRun: false,
 }
 
 const oneCodeBlock = ` comment blah

--- a/src/getContext.ts
+++ b/src/getContext.ts
@@ -1,15 +1,15 @@
 import {getInput} from '@actions/core'
 
 export interface Context {
-  token: string;
-  owner: string;
-  name: string;
-  label: string;
-  tag: string;
-  issue: string | undefined;
-  bisect: string | undefined;
-  workspace: string;
-  dryRun: boolean;
+  token: string
+  owner: string
+  name: string
+  label: string
+  tag: string
+  issue: string | undefined
+  bisect: string | undefined
+  workspace: string
+  dryRun: boolean
 }
 
 export const getContext = () => {
@@ -33,7 +33,7 @@ export const getContext = () => {
     issue,
     bisect,
     workspace,
-    dryRun,
+    dryRun
   }
 
   return ctx

--- a/src/getContext.ts
+++ b/src/getContext.ts
@@ -1,6 +1,16 @@
 import {getInput} from '@actions/core'
 
-export type Context = ReturnType<typeof getContext>
+export interface Context {
+  token: string;
+  owner: string;
+  name: string;
+  label: string;
+  tag: string;
+  issue: string | undefined;
+  bisect: string | undefined;
+  workspace: string;
+  dryRun: boolean;
+}
 
 export const getContext = () => {
   const token = getInput('github-token') || process.env.GITHUB_TOKEN!
@@ -8,20 +18,22 @@ export const getContext = () => {
   const workspace = process.env.GITHUB_WORKSPACE!
   const label = getInput('label') || 'Has Repro'
   const tag = getInput('code-tag') || 'repro'
-  const runIssue = getInput('issue') || process.env.ISSUE
-  const bisectIssue = getInput('bisect') || (process.env.BISECT_ISSUE as string | undefined)
+  const issue = getInput('issue') || process.env.ISSUE
+  const bisect = getInput('bisect') || (process.env.BISECT as string | undefined)
   const owner = repo.split('/')[0]
   const name = repo.split('/')[1]
+  const dryRun = !!process.env.DRY
 
-  const ctx = {
+  const ctx: Context = {
     token,
     owner,
     name,
     label,
     tag,
-    runIssue,
-    bisectIssue,
-    workspace
+    issue,
+    bisect,
+    workspace,
+    dryRun,
   }
 
   return ctx

--- a/src/getIssues.ts
+++ b/src/getIssues.ts
@@ -33,8 +33,8 @@ export async function getIssue(context: Context, issue: number): Promise<Issue> 
 
 export async function getIssues(context: Context): Promise<Issue[]> {
   const octokit = getOctokit(context.token)
-  if (context.runIssue) {
-    return [await getIssue(context, parseInt(context.runIssue, 10))]
+  if (context.issue) {
+    return [await getIssue(context, parseInt(context.issue, 10))]
   }
 
   const req = issuesQuery(context.owner, context.name, context.label)

--- a/src/gitBisectTypeScript.ts
+++ b/src/gitBisectTypeScript.ts
@@ -109,20 +109,24 @@ function getRevisionsFromComment(
   }
 }
 
-function tryGetRevisionsFromText(text: string, request: TwoslashRequest, context: Context): BisectRevisions | undefined {
+function tryGetRevisionsFromText(
+  text: string,
+  request: TwoslashRequest,
+  context: Context
+): BisectRevisions | undefined {
   const match = text.match(bisectCommentRegExp)
   if (match) {
     const [, oldLabel, newLabel] = match
     const oldRef = execSync(`git merge-base ${oldLabel} main`, {cwd: context.workspace, encoding: 'utf8'}).trim()
-      execSync(`git checkout ${oldRef}`, {cwd: context.workspace})
-      const oldResult = buildAndRun(request, context)
-      return {
-        oldRef,
-        newRef: newLabel,
-        oldLabel,
-        newLabel,
-        oldResult
-      }
+    execSync(`git checkout ${oldRef}`, {cwd: context.workspace})
+    const oldResult = buildAndRun(request, context)
+    return {
+      oldRef,
+      newRef: newLabel,
+      oldLabel,
+      newLabel,
+      oldResult
+    }
   }
 }
 

--- a/src/gitBisectTypeScript.ts
+++ b/src/gitBisectTypeScript.ts
@@ -20,6 +20,7 @@ export async function gitBisectTypeScript(context: Context, issue: Issue): Promi
   const request = requests[requests.length - 1]
   const resultComment = request && getResultCommentInfoForRequest(issue.comments.nodes, request)
   const bisectRevisions =
+    getRevisionsFromContext(context, request) ||
     getRevisionsFromComment(issue, request, context) ||
     (resultComment && getRevisionsFromPreviousRun(resultComment, context))
   if (!bisectRevisions) return
@@ -85,10 +86,9 @@ function getRevisionsFromPreviousRun(
     const oldRef = `v${oldResult.label}`
     const newRef = newResult.label === 'Nightly' ? resultComment.info.typescriptSha : `v${newResult.label}`
     const oldMergeBase = execSync(`git merge-base ${oldRef} main`, {cwd: context.workspace, encoding: 'utf8'}).trim()
-    const newMergeBase = execSync(`git merge-base ${newRef} main`, {cwd: context.workspace, encoding: 'utf8'}).trim()
     return {
       oldRef: oldMergeBase,
-      newRef: newMergeBase,
+      newRef,
       oldLabel: oldResult.label,
       newLabel: newResult.label,
       oldResult
@@ -96,7 +96,7 @@ function getRevisionsFromPreviousRun(
   }
 }
 
-const bisectCommentRegExp = /^@typescript-bot bisect (?:this )?(?:good|old) ([^\s]+) (?:bad|new) ([^\s]+)/
+const bisectCommentRegExp = /^(?:@typescript-bot bisect (?:this )?)?(?:good|old) ([^\s]+) (?:bad|new) ([^\s]+)/
 function getRevisionsFromComment(
   issue: Issue,
   request: TwoslashRequest,
@@ -104,22 +104,30 @@ function getRevisionsFromComment(
 ): BisectRevisions | undefined {
   for (let i = issue.comments.nodes.length - 1; i >= 0; i--) {
     const comment = issue.comments.nodes[i]
-    const match = comment.body.match(bisectCommentRegExp)
-    if (match) {
-      const [, oldLabel, newLabel] = match
-      const oldRef = execSync(`git merge-base ${oldLabel} main`, {cwd: context.workspace, encoding: 'utf8'}).trim()
-      const newRef = execSync(`git merge-base ${newLabel} main`, {cwd: context.workspace, encoding: 'utf8'}).trim()
+    const revs = tryGetRevisionsFromText(comment.body, request, context)
+    if (revs) return revs
+  }
+}
+
+function tryGetRevisionsFromText(text: string, request: TwoslashRequest, context: Context): BisectRevisions | undefined {
+  const match = text.match(bisectCommentRegExp)
+  if (match) {
+    const [, oldLabel, newLabel] = match
+    const oldRef = execSync(`git merge-base ${oldLabel} main`, {cwd: context.workspace, encoding: 'utf8'}).trim()
       execSync(`git checkout ${oldRef}`, {cwd: context.workspace})
       const oldResult = buildAndRun(request, context)
       return {
         oldRef,
-        newRef,
+        newRef: newLabel,
         oldLabel,
         newLabel,
         oldResult
       }
-    }
   }
+}
+
+function getRevisionsFromContext(context: Context, request: TwoslashRequest): BisectRevisions | undefined {
+  return tryGetRevisionsFromText(context.bisect!, request, context)
 }
 
 function buildAndRun(request: TwoslashRequest, context: Context) {

--- a/src/updatesIssue.ts
+++ b/src/updatesIssue.ts
@@ -10,7 +10,7 @@ import {API} from './utils/api'
 import {getTypeScriptNightlyVersion} from './utils/getTypeScriptNightlyVersion'
 import {TwoslashRequest} from './getRequestsFromIssue'
 import {BisectResult} from './gitBisectTypeScript'
-import { Context } from './getContext'
+import {Context} from './getContext'
 
 export async function fixOrDeleteOldComments(issue: Issue, api: API, context: Context): Promise<Issue> {
   const outdatedComments = getAllTypeScriptBotComments(issue.comments.nodes)

--- a/src/updatesIssue.ts
+++ b/src/updatesIssue.ts
@@ -10,13 +10,16 @@ import {API} from './utils/api'
 import {getTypeScriptNightlyVersion} from './utils/getTypeScriptNightlyVersion'
 import {TwoslashRequest} from './getRequestsFromIssue'
 import {BisectResult} from './gitBisectTypeScript'
+import { Context } from './getContext'
 
-export async function fixOrDeleteOldComments(issue: Issue, api: API): Promise<Issue> {
+export async function fixOrDeleteOldComments(issue: Issue, api: API, context: Context): Promise<Issue> {
   const outdatedComments = getAllTypeScriptBotComments(issue.comments.nodes)
     .filter(c => c.info.version !== 1)
     .map(c => c.comment)
-  for (const comment of outdatedComments) {
-    await api.deleteComment(comment.id)
+  if (!context.dryRun) {
+    for (const comment of outdatedComments) {
+      await api.deleteComment(comment.id)
+    }
   }
   if (outdatedComments.length) {
     return {


### PR DESCRIPTION
Change described https://github.com/microsoft/TypeScript/issues/50670#issuecomment-1244232538:

> The issue with the bisect was that the culprit commit was cherry-picked from main to release-4.5, and I only look at the timeline of commits going into main. I’m far from a git expert, but (warning: likely butchering terminology ahead) `git bisect` gets mad if you give it a pair like `v4.4.4` and `v4.5.5` because those tags exist on separate branches off of main that never reunite with main. To account for that, I actually run the bisect between the `merge-base` of the respective inputs and main, so I’m actually bisecting between the point where `release-4.4` and `release-4.5` branched off of main. But in hindsight I think I only need to take the merge-base of the old ref. There still might be a problem if the behavior is different between the old ref and its merge base with main, though. I think that should be less common.

This also changes the GH Action API a bit; TypeScript PR incoming.