### PR TITLE
Use --first-parent when starting bisect

### DIFF
--- a/src/utils/gitBisect.ts
+++ b/src/utils/gitBisect.ts
@@ -10,7 +10,7 @@ export function gitBisect(
   sha: string
   output: string
 }> {
-  execSync(`git bisect start ${newRef} ${oldRef} -- ./src`, {cwd})
+  execSync(`git bisect start --first-parent ${newRef} ${oldRef} -- ./src`, {cwd})
 
   const server = createServer(async (_, res) => {
     try {


### PR DESCRIPTION
This flag prevents `git bisect` from traversing back into branches that were merged into `main` (i.e. not squashed), instead opting to blame the merge commit itself if that's when the behavior changed.

The module conversion PR is going to be merged via a merge commit as to allow `git blame` to ignore certain automated commits, so this flag would prevent `git bisect` from attempting to look at the commits on the branch and potentially fail in the early stages of the branch where the build hasn't been fixed.

This probably also helps with bisecting changes introduced in very old versions of TS where we weren't so vigilant about squashing; I've bisected changes down to commits within PRs before (which has the potential to be useful), but in general it's not safe as the branch is free to contain broken changes that never appeared in `main`.

See: https://git-scm.com/docs/git-bisect#Documentation/git-bisect.txt---first-parent